### PR TITLE
Preserve pedantic include in analysis_options.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.0.0 as build
+FROM google/dart:2.1.1 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/lib/src/update.dart
+++ b/lib/src/update.dart
@@ -140,7 +140,7 @@ analyzer:
     final bool wasPresentCommented =
         commentedOutLintRule.hasMatch(currentAnalysisOptionsString);
     final bool wasPresent =
-        getYamlValue(currentAnalysisOptions, 'linter:rules:$lint');
+        getYamlValue(currentAnalysisOptions, 'linter:rules:$lint') ?? false;
 
     String issues = _lintResultFor(lint, lintErrorCounts);
     final bool hasIssues = issues.isNotEmpty;

--- a/lib/src/update.dart
+++ b/lib/src/update.dart
@@ -216,7 +216,9 @@ $output
 ''');
   }
   String finalOutput = sb.toString();
-  new File(analysisOptionsFilename).writeAsStringSync(finalOutput);
+  if (writeToFile) {
+    new File(analysisOptionsFilename).writeAsStringSync(finalOutput);
+  }
   if (!all) {
     print('Wrote $analysisOptionsFilename');
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -67,7 +67,7 @@ YamlMap loadAnalysisOptions(
   if (pathToAnalysisOptionsFile != null) {
     return loadYamlFile(pathToAnalysisOptionsFile);
   } else {
-    loadYamlFile(findAnalysisOptionsFile(
+    return loadYamlFile(findAnalysisOptionsFile(
         renameDeprecatedFilename: renameDeprecatedFilename));
   }
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -62,12 +62,19 @@ YamlMap loadPubspec() => loadYamlFile(pubspecFilename);
 YamlMap loadSmithy() =>
     loadYamlFile(smithyFilename) ?? loadYamlFile(smithyFilename2);
 
-YamlMap loadAnalysisOptions({bool renameDeprecatedFilename: false}) =>
+YamlMap loadAnalysisOptions(
+    {String pathToAnalysisOptionsFile, bool renameDeprecatedFilename: false}) {
+  if (pathToAnalysisOptionsFile != null) {
+    return loadYamlFile(pathToAnalysisOptionsFile);
+  } else {
     loadYamlFile(findAnalysisOptionsFile(
         renameDeprecatedFilename: renameDeprecatedFilename));
+  }
+}
 
-String loadAnalysisOptionsAsString() {
-  final String filename = findAnalysisOptionsFile();
+String loadAnalysisOptionsAsString({String pathToAnalysisOptionsFile}) {
+  final String filename =
+      pathToAnalysisOptionsFile ?? findAnalysisOptionsFile();
   if (filename == null) {
     return '';
   }

--- a/test/fixtures/analysis/includes_pedantic/analysis_options.yaml
+++ b/test/fixtures/analysis/includes_pedantic/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/test/vm/check_test.dart
+++ b/test/vm/check_test.dart
@@ -43,7 +43,7 @@ Future<Null> main() async {
     }
   });
 
-  group('Verifiy pubspec check', () {
+  group('Verify pubspec check', () {
     final YamlMap pubspec = loadPubspec();
     final YamlMap pubspecWithMissingDeps =
         loadYamlFile('test/fixtures/pubspec_missing_deps.yaml');

--- a/test/vm/update_test.dart
+++ b/test/vm/update_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2017-2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+import 'package:abide/src/util.dart';
+import 'package:abide/src/update.dart';
+
+void main() async {
+  YamlMap abideYaml = await loadAbideYaml();
+
+  group('Update', () {
+    test('preserves an existing include key', () async {
+      String result = await updateAnalysisOption(abideYaml,
+          pathToAnalysisOptionsFile:
+              'test/fixtures/analysis/includes_pedantic/analysis_options.yaml',
+          uncommentClean: false,
+          writeToFile: false);
+      YamlMap yamlOutput = loadYaml(result);
+      expect(yamlOutput['include'] == 'package:pedantic/analysis_options.yaml',
+          isTrue);
+    });
+  });
+}

--- a/test/vm/update_test.dart
+++ b/test/vm/update_test.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 @TestOn('vm')
+import 'dart:async';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 

--- a/test/vm/update_test.dart
+++ b/test/vm/update_test.dart
@@ -19,7 +19,7 @@ import 'package:yaml/yaml.dart';
 import 'package:abide/src/util.dart';
 import 'package:abide/src/update.dart';
 
-void main() async {
+Future<Null> main() async {
   YamlMap abideYaml = await loadAbideYaml();
 
   group('Update', () {


### PR DESCRIPTION
# Overview
Fixes https://github.com/Workiva/abide/issues/7
If an analysis options YAML has an include key it should be preserved in the output yaml file.
Some internal methods were modified to ease testing the update functionality

# Testing
- CI passes
