### PR TITLE
Add strict language rules

### DIFF
--- a/lib/src/update.dart
+++ b/lib/src/update.dart
@@ -87,6 +87,15 @@ String generateAnalyisOptionsContent(
   }
   sb.write('''
 analyzer:
+  
+  # Enable stricter analyzer settings to find more runtime type errors at analysis time.
+  # See https://github.com/dart-lang/sdk/issues/33119 and
+  # https://github.com/dart-lang/sdk/issues/33749
+  # for more information
+  language:
+    strict-inference: true
+    strict-raw-types: true
+  
   # Strong mode is required. Applies to the current project.
   strong-mode:
     # When compiling to JS, both implicit options apply to the current 


### PR DESCRIPTION
## Changes
Adds strict language checks to the generated analysis_options.yaml file
```
analyzer:
  language:
    strict-inference: true
    strict-raw-types: true
```
See https://github.com/dart-lang/sdk/issues/33119 and https://github.com/dart-lang/sdk/issues/33749 for more information

TODO: Add checks for these to check.dart