### PR TITLE
remove smithy-runner-generator

### DIFF
--- a/test/fixtures/DockerfileNoRunCommand
+++ b/test/fixtures/DockerfileNoRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithChainedDartCommand
+++ b/test/fixtures/DockerfileWithChainedDartCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithCommentedDartCommand
+++ b/test/fixtures/DockerfileWithCommentedDartCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithCommentedMakeCommand
+++ b/test/fixtures/DockerfileWithCommentedMakeCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithCommentedRunCommand
+++ b/test/fixtures/DockerfileWithCommentedRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithDartCommandContainingCommentedRunCommand
+++ b/test/fixtures/DockerfileWithDartCommandContainingCommentedRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithMakeCommandContainingRunCommand
+++ b/test/fixtures/DockerfileWithMakeCommandContainingRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithRunCommand
+++ b/test/fixtures/DockerfileWithRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithRunCommandAndCommentedRunCommand
+++ b/test/fixtures/DockerfileWithRunCommandAndCommentedRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithScriptContainingCommentedRunCommand
+++ b/test/fixtures/DockerfileWithScriptContainingCommentedRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithScriptContainingRunCommand
+++ b/test/fixtures/DockerfileWithScriptContainingRunCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithTaskRunner
+++ b/test/fixtures/DockerfileWithTaskRunner
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/DockerfileWithUnchainedDartCommand
+++ b/test/fixtures/DockerfileWithUnchainedDartCommand
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM google/dart:1.24.3 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test/fixtures/smithy_no_run_command.yaml
+++ b/test/fixtures/smithy_no_run_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_commented_dart_command.yaml
+++ b/test/fixtures/smithy_with_commented_dart_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_commented_make_command.yaml
+++ b/test/fixtures/smithy_with_commented_make_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_commented_run_command.yaml
+++ b/test/fixtures/smithy_with_commented_run_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_dart_command.yaml
+++ b/test/fixtures/smithy_with_dart_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_dart_command_containing_commented_run_command.yaml
+++ b/test/fixtures/smithy_with_dart_command_containing_commented_run_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_make_command_containing_run_command.yaml
+++ b/test/fixtures/smithy_with_make_command_containing_run_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_run_command.yml
+++ b/test/fixtures/smithy_with_run_command.yml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_script_containing_commented_run_command.yaml
+++ b/test/fixtures/smithy_with_script_containing_commented_run_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_script_containing_run_command.yaml
+++ b/test/fixtures/smithy_with_script_containing_run_command.yaml
@@ -1,7 +1,7 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version

--- a/test/fixtures/smithy_with_task_runner.yaml
+++ b/test/fixtures/smithy_with_task_runner.yaml
@@ -4,7 +4,7 @@ language: dart
 env:
   - CODECOV_TOKEN='abc123'
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: google/dart:1.24.3 # Dart 1.24.2
 
 script:
   - dart --version


### PR DESCRIPTION
@jeffhall-wk @stevenosborne-wf .. skynet is failing because this is dart 1.. I'd vote to approve skynet runs for these and mash merge

also, this PR isn't for vuln hunting.. I'm tired of finding these references in github searches