### PR TITLE
Remove deprecated authors field from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,6 @@
 name: 'abide'
 version: 1.6.5
 description: A command line tool to manage analysis_options.yaml and check if it abides by requirements.
-authors: 
-  - Workiva Client Platform Team <clientplatform@workiva.com>
-  - Rob Becker <rob.becker@workiva.com>
-  - Sebastian Malysa <sebastian.malysa@workiva.com>
   
 homepage: https://github.com/Workiva/abide
 

--- a/test/fixtures/dart1_project/pubspec.yaml
+++ b/test/fixtures/dart1_project/pubspec.yaml
@@ -1,7 +1,6 @@
 name: 'dart1_project'
 version: 1.1.0
 description: mock description
-author: Mock Author <mock.author@workiva.com>
 homepage: https://github.com/Workiva/mock_name
 publish_to: https://pub.workiva.org
 

--- a/test/fixtures/dart2_project/pubspec.yaml
+++ b/test/fixtures/dart2_project/pubspec.yaml
@@ -1,7 +1,6 @@
 name: 'dart2_project'
 version: 1.1.0
 description: mock description
-author: Mock Author <mock.author@workiva.com>
 homepage: https://github.com/Workiva/mock_name
 publish_to: https://pub.workiva.org
 

--- a/test/fixtures/dep_validator_pubspec.yaml
+++ b/test/fixtures/dep_validator_pubspec.yaml
@@ -1,7 +1,6 @@
 name: 'dependency_validator'
 version: 1.1.0
 description: mock description
-author: Mock Author <mock.author@workiva.com>
 homepage: https://github.com/Workiva/mock_name
 publish_to: https://pub.workiva.org
 

--- a/test/fixtures/semver_audit_pubspec.yaml
+++ b/test/fixtures/semver_audit_pubspec.yaml
@@ -1,7 +1,6 @@
 name: 'semver_audit'
 version: 1.1.0
 description: mock description
-author: Mock Author <mock.author@workiva.com>
 homepage: https://github.com/Workiva/mock_name
 publish_to: https://pub.workiva.org
 

--- a/upgrade/pubspec.yaml
+++ b/upgrade/pubspec.yaml
@@ -1,7 +1,6 @@
 name: 'abide_upgrade'
 version: 1.0.0
 description: A command line tool to update abide.yaml
-author: Rob Becker <rob.becker@workiva.com>
 homepage: https://github.com/Workiva/abide
 
 environment:


### PR DESCRIPTION
This PR removes the author field from any `pubspec.yaml` files in this repo,
as the field was deprecated in Dart 2.7 and is no longer needed.

Removing this field will silence the warning that `pub publish` emits, which
has the added benefit of allowing us to use `pub publish --dry-run` as a
quality check during CI.

If you'd like to retain the author information, we recommend adding an
`AUTHORS.md` file in the repo or the package directory.

---

This PR was created automatically from a Sourcegraph batch change.
Please reach out to @evanweible-wf or #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_pubspec_authors`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_pubspec_authors)