### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ ADD . /build/
 
 RUN echo "Starting the script sections" && \
 	dart --version && \
-	pub get && \
-	dartfmt --set-exit-if-changed --dry-run lib bin test tool && \ 
-	pub run dependency_validator -x upgrade/ -i dart_dev && \
-	pub run dart_dev analyze && \
-	pub run abide || echo Abide would have failed CI. && \
-	pub run test --concurrency=4 -p vm --reporter=expanded test/vm/ && \
+	dart pub get && \
+	dart format --set-exit-if-changed --dry-run lib bin test tool && \ 
+	dart run dependency_validator -x upgrade/ -i dart_dev && \
+	dart run dart_dev analyze && \
+	dart run abide || echo Abide would have failed CI. && \
+	dart test --concurrency=4 -p vm --reporter=expanded test/vm/ && \
 	tar czvf abide.pub.tgz LICENSE README.md pubspec.yaml analysis_options.yaml lib/ bin/ && \
 	echo "Script sections completed"
 ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock

--- a/test/fixtures/dart/commented_run_command.sh
+++ b/test/fixtures/dart/commented_run_command.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "running abide"
-#pub run abide
-#pub run dependency_validator
+#dart run abide
+#dart run dependency_validator
 exit 0

--- a/test/fixtures/dart/run_command.sh
+++ b/test/fixtures/dart/run_command.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "running abide"
-pub run abide
-pub run dependency_validator
+dart run abide
+dart run dependency_validator
 
 exit 0


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)